### PR TITLE
Update example on homepage of helm-engine.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,9 +68,6 @@ render :: (Int, Int) -> Element
 render (w, h) = collage w h [move (100, 100) $ filled red $ square 64]
 
 main :: IO ()
-main = do
-  engine <- startup defaultConfig
-
-  run engine $ render <~ Window.dimensions engine
+main = run defaultConfig $ render <~ Window.dimensions
   {% endhighlight %}
 </div>


### PR DESCRIPTION
I got Helm installed and copy-pasted the example from helm-engine.org into my editor. `FRP.Helm` appears to no longer export `startup`, so the code didn't compile. This updates the sample code to match that in the README.

Unfortunately this means losing the nice visual alignment where the sample code is the same height as the "Get Started" section to its left, but demonstrating correct code is more important.